### PR TITLE
feat(java25): add JEP 511 — Module Import Declarations demo

### DIFF
--- a/src/main/java/org/javademos/Main.java
+++ b/src/main/java/org/javademos/Main.java
@@ -52,6 +52,7 @@ public class Main {
         demoPool.addAll(Java22.getDemos());
         // newer demos - each JEP has separate file with info/examples
         demoPool.addAll(Java23.getDemos());
+        demoPool.addAll(Java25.getDemos());
         
         // run method .demo() on each entry to see the output
         demoPool.forEach(IDemo::demo);

--- a/src/main/java/org/javademos/commons/JEPInfo.java
+++ b/src/main/java/org/javademos/commons/JEPInfo.java
@@ -18,7 +18,7 @@ public class JEPInfo {
     private static Map<Integer, JEPDataInfo> getAllEntries() {
         var jeps = new HashMap<Integer, JEPDataInfo>();
 
-        var sources = Arrays.asList(21, 22, 23);
+        var sources = Arrays.asList(21, 22, 23, 25);
         for (Integer src : sources) {
             var srcFile = MessageFormat.format("/JDK{0}Info.json", src);
             try (InputStream inputStream = JEPInfo.class.getResourceAsStream(srcFile)) {

--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -1,0 +1,22 @@
+package org.javademos.init;
+
+import org.javademos.commons.IDemo;
+import org.javademos.java25.jep511.ModuleImportDeclarations;
+
+import java.util.ArrayList;
+
+public class Java25 {
+
+    /**
+     * @return list of demos available for JDK 25
+     */
+    public static ArrayList<IDemo> getDemos() {
+        var java25DemoPool = new ArrayList<IDemo>();
+
+        // feel free to comment out demos you are not interested in right now
+        java25DemoPool.add(new ModuleImportDeclarations());
+
+        return java25DemoPool;
+    }
+
+}

--- a/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
+++ b/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
@@ -12,7 +12,7 @@ import org.javademos.commons.IDemo;
 /// Further reading:
 /// - [Simplifying Java Development with Module Import](https://www.infoq.com/news/2024/05/simplifying-java-module-import/)
 ///
-/// @author alois.seckar@gmail.com
+/// @author Arjun Vijay Prakash @ArjunCodess
 
 public class ModuleImportDeclarations implements IDemo {
 

--- a/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
+++ b/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
@@ -2,6 +2,8 @@ package org.javademos.java25.jep511;
 
 import org.javademos.commons.IDemo;
 
+import module java.base;
+
 /// Demo for JDK 25 feature **Module Import Declarations** (JEP 511)
 ///
 /// JEP history:
@@ -19,6 +21,18 @@ public class ModuleImportDeclarations implements IDemo {
     @Override
     public void demo() {
         info(511);
+
+        System.out.println("using 'import module java.base;' to bring exported types into scope");
+        System.out.println("no explicit package imports for List/ArrayList/Arrays/Math/Path are needed\n");
+
+        // examples of types from multiple packages within module java.base
+        List<String> values = new ArrayList<>(Arrays.asList("a", "b", "c"));
+        System.out.println("values: " + values);
+        System.out.println("random: " + Math.random());
+        System.out.println("path:   " + Path.of("/tmp"));
+
+        // in case of name conflicts across modules, add explicit class imports
+        // or use fully-qualified names for the ambiguous types
     }
 
 }

--- a/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
+++ b/src/main/java/org/javademos/java25/jep511/ModuleImportDeclarations.java
@@ -1,0 +1,24 @@
+package org.javademos.java25.jep511;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 25 feature **Module Import Declarations** (JEP 511)
+///
+/// JEP history:
+/// - JDK 23: [JEP 476 - Module Import Declarations (Preview)](https://openjdk.org/jeps/476)
+/// - JDK 24: [JEP 494 - Module Import Declarations (Second Preview)](https://openjdk.org/jeps/494)
+/// - JDK 25: [JEP 511 - Module Import Declarations](https://openjdk.org/jeps/511)
+///
+/// Further reading:
+/// - [Simplifying Java Development with Module Import](https://www.infoq.com/news/2024/05/simplifying-java-module-import/)
+///
+/// @author alois.seckar@gmail.com
+
+public class ModuleImportDeclarations implements IDemo {
+
+    @Override
+    public void demo() {
+        info(511);
+    }
+
+}

--- a/src/main/resources/JDK25Info.json
+++ b/src/main/resources/JDK25Info.json
@@ -1,0 +1,9 @@
+[
+  {
+    "jep": 511,
+    "info": {
+      "name": "JEP 511 - Module Import Declarations",
+      "dscr": "Java 25 finalizes module import declarations; see ModuleImportDeclarations.java for details"
+    }
+  }
+]


### PR DESCRIPTION
closes #39

- implement demo for java 25 feature jep 511 — module import declarations
- add `org.javademos.java25.jep511.ModuleImportDeclarations` implementing `IDemo`
- include unified markdown header with jep history and external link
- add `JDK25Info.json` entry for jep 511 and load it in `JEPInfo`
- add `org.javademos.init.Java25` and wire it into `Main.java`

references:
- jep 511 issue [#39](https://github.com/AloisSeckar/demos-java/issues/39)
- jdk 25 tracker [#29](https://github.com/AloisSeckar/demos-java/issues/29)

- implemented and integrated the java 25 jep 511 demo, registered it in `Java25`, updated `Main`, and added `JDK25Info.json` with loader support in `JEPInfo`.