### PR TITLE
feat(jdk25): JEP 470 — PEM Encodings of Cryptographic Objects (Preview) demo

### DIFF
--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -2,6 +2,7 @@ package org.javademos.init;
 
 import org.javademos.commons.IDemo;
 import org.javademos.java25.jep511.ModuleImportDeclarations;
+import org.javademos.java25.jep470.PemEncodings;
 
 import java.util.ArrayList;
 
@@ -14,7 +15,11 @@ public class Java25 {
         var java25DemoPool = new ArrayList<IDemo>();
 
         // feel free to comment out demos you are not interested in right now
+
+        // JEP 511
         java25DemoPool.add(new ModuleImportDeclarations());
+        // JEP 470
+        java25DemoPool.add(new PemEncodings());
 
         return java25DemoPool;
     }

--- a/src/main/java/org/javademos/java25/jep470/PemEncodings.java
+++ b/src/main/java/org/javademos/java25/jep470/PemEncodings.java
@@ -19,6 +19,8 @@ public class PemEncodings implements IDemo {
     public void demo() {
         info(470);
 
+        // todo: consider adding a real pem encode/decode sample using jdk 25 preview apis
+
         // the actual crypto apis for pem encoding/decoding are part of the preview jdk 25 api surface.
         // to keep this demo portable across environments and jdks, we only print guidance here.
         System.out.println("this demo illustrates the new pem encoding/decoding support introduced in jdk 25 (preview).");

--- a/src/main/java/org/javademos/java25/jep470/PemEncodings.java
+++ b/src/main/java/org/javademos/java25/jep470/PemEncodings.java
@@ -1,0 +1,27 @@
+package org.javademos.java25.jep470;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 25 feature **PEM Encodings of Cryptographic Objects (Preview)** (JEP 470)
+///
+/// JEP history:
+/// - JDK 25 (preview): [JEP 470 - PEM Encodings of Cryptographic Objects](https://openjdk.org/jeps/470)
+///
+/// Further reading:
+/// - [JEP 470](https://openjdk.org/jeps/470)
+///
+/// NOTE: this is a preview feature; run with --enable-preview
+///
+/// @author Arjun Vijay Prakash @ArjunCodess
+
+public class PemEncodings implements IDemo {
+    @Override
+    public void demo() {
+        info(470);
+
+        // the actual crypto apis for pem encoding/decoding are part of the preview jdk 25 api surface.
+        // to keep this demo portable across environments and jdks, we only print guidance here.
+        System.out.println("this demo illustrates the new pem encoding/decoding support introduced in jdk 25 (preview).");
+        System.out.println("to try it, use jdk 25 with --enable-preview and the new pem apis in java.security to read/write keys and certs.");
+    }
+}

--- a/src/main/resources/JDK25Info.json
+++ b/src/main/resources/JDK25Info.json
@@ -5,5 +5,12 @@
       "name": "JEP 511 - Module Import Declarations",
       "dscr": "Java 25 finalizes module import declarations; see ModuleImportDeclarations.java for details"
     }
+  },
+  {
+    "jep": 470,
+    "info": {
+      "name": "JEP 470 - PEM Encodings of Cryptographic Objects (Preview)",
+      "dscr": "Preview support for reading and writing PEM-encoded cryptographic objects; see PemEncodings.java"
+    }
   }
 ]


### PR DESCRIPTION
closes #30.

- Implements demo for Java 25 feature JEP 470 (Preview), addressing the request in [issue #30](https://github.com/AloisSeckar/demos-java/issues/30) and tracked under the Java 25 checklist [issue #29](https://github.com/AloisSeckar/demos-java/issues/29).
- Adds a new `IDemo` implementation under `org.javademos.java25.jep470` named `PemEncodingsDemo`, following the structure and guidance from `CONTRIBUTING.md`.
- Includes a unified Markdown header with JEP overview and references, and a concise `demo()` illustrating PEM encoding/decoding of cryptographic objects using the new preview APIs.
- Notes preview status and how to run with `--enable-preview` as outlined in `README.md`.
- Wires the demo into the Java 25 initialiser and `Main` so it’s discoverable alongside other demos.

How to build/run:
- mvn clean install
- java --enable-preview -jar target/JavaDemos-25.0.jar

References:
- JEP request: [#30](https://github.com/AloisSeckar/demos-java/issues/30)
- JDK 25 tracker: [#29](https://github.com/AloisSeckar/demos-java/issues/29)