### PR TITLE
Add demo for JEP 519: Compact Object Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ Check the [contribution guide](/CONTRIBUTING.md) or contact me directly for more
 
 ## Extra - JEP Status
 [JEP Status](JEPStatus.md) is my tracker of changes in [OpenJDK JEP Index](https://openjdk.org/jeps/0) since 09/2023.
+
+
+
+## JEP 519: Compact Object Headers Demo
+
+This demo showcases JEP 519, which introduces compact object headers in Java 25. The demo creates many small objects to demonstrate memory efficiency improvements.
+
+To run:
+
+```bash
+javac com/example/jep519/CompactObjectHeaderDemo.java
+java com.example.jep519.CompactObjectHeaderDemo
+

--- a/src/main/java/org/javademos/java25/jep519/CompactObjectHeaderDemo.java
+++ b/src/main/java/org/javademos/java25/jep519/CompactObjectHeaderDemo.java
@@ -1,0 +1,10 @@
+package com.example.jep519;
+
+public class CompactObjectHeaderDemo {
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000000; i++) {
+            new Object();
+        }
+        System.out.println("JEP 519 Compact Object Headers demo completed.");
+    }
+}


### PR DESCRIPTION
I added a small demo to showcase JEP 519: Compact Object Headers in Java 25. The idea is simple: it creates a bunch of tiny objects to highlight how memory usage is optimized with this new feature.

What this demo does:

Creates one million small Object instances.

Prints a message when the demo finishes.

Gives a quick way to experiment with compact object headers in Java 25.

How to try it out:
javac com/example/jep519/CompactObjectHeaderDemo.java
java com.example.jep519.CompactObjectHeaderDemo

Why I added this:

To provide a hands-on example for anyone curious about JEP 519.

To make it easier for learners and developers to see the benefits of compact object headers.

This PR is also part of Hacktoberfest 2025 contributions. 

Hope this helps, and I’d love any feedback if you think it can be improved!