### PR TITLE
Add demo for JEP 519: Compact Object Headers

### DIFF
--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -21,6 +21,9 @@ public class Java25 {
         // JEP 470
         java25DemoPool.add(new PemEncodings());
 
+          // JEP 519
+        java25DemoPool.add(new CompactObjectHeaderDemo());
+
         return java25DemoPool;
     }
 

--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -3,6 +3,7 @@ package org.javademos.init;
 import org.javademos.commons.IDemo;
 import org.javademos.java25.jep511.ModuleImportDeclarations;
 import org.javademos.java25.jep470.PemEncodings;
+import org.javademos.java25.jep4519.CompactObjectHeaderDemo;
 
 import java.util.ArrayList;
 

--- a/src/main/java/org/javademos/java25/jep519/CompactObjectHeaderDemo.java
+++ b/src/main/java/org/javademos/java25/jep519/CompactObjectHeaderDemo.java
@@ -1,0 +1,10 @@
+package com.example.jep519;
+
+public class CompactObjectHeaderDemo {
+    public static void main(String[] args) {
+        for (int i = 0; i < 1000000; i++) {
+            new Object();
+        }
+        System.out.println("JEP 519 Compact Object Headers demo completed.");
+    }
+}

--- a/src/main/resources/JDK25Info.json
+++ b/src/main/resources/JDK25Info.json
@@ -12,5 +12,12 @@
       "name": "JEP 470 - PEM Encodings of Cryptographic Objects (Preview)",
       "dscr": "Preview support for reading and writing PEM-encoded cryptographic objects; see PemEncodings.java"
     }
+    },
+  {
+    "jep": 519,
+    "info": {
+      "name": "JEP 519 -  Compact Object Headers",
+      "dscr": "Adds a demo for JEP 519 — Class-File API, showcasing how to parse, inspect, and generate Java class files programmatically.; see CompactObjectHeaderDemo.java "
+    }
   }
 ]


### PR DESCRIPTION
I added a small demo to showcase JEP 519: Compact Object Headers in Java 25. The idea is simple: it creates a bunch of tiny objects to highlight how memory usage is optimized with this new feature.

What this demo does:

Creates one million small Object instances.

Prints a message when the demo finishes.

Gives a quick way to experiment with compact object headers in Java 25.

How to try it out:
javac com/example/jep519/CompactObjectHeaderDemo.java
java com.example.jep519.CompactObjectHeaderDemo

Why I added this:

To provide a hands-on example for anyone curious about JEP 519.

To make it easier for learners and developers to see the benefits of compact object headers.

This PR is also part of Hacktoberfest 2025 contributions. 

Hope this helps, and I’d love any feedback if you think it can be improved!