### PR TITLE
Add JEP 514 - Ahead-of-Time CLI Ergonomics Demo

### DIFF
--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -3,17 +3,14 @@ package org.javademos.init;
 import org.javademos.commons.IDemo;
 import org.javademos.java25.jep511.ModuleImportDeclarations;
 import org.javademos.java25.jep515.AheadOfTimeMethodProfiling;
+import org.javademos.java25.jep514.AheadOfTimeCLI; 
 import org.javademos.java25.jep470.PemEncodings;
 import org.javademos.java25.jep519.CompactObjectHeaderDemo;
 import org.javademos.java25.jep518.JFRCooperativeSampling;
 import org.javademos.java25.jep509.CpuTimeProfilingDemo;
 import org.javademos.java25.jep508.VectorApiDemo;
 import org.javademos.java25.jep506.ScopedValuesDemo;
-
 import org.javademos.java25.jep502.StableValuesDemo;
-
-
-
 
 import java.util.ArrayList;
 
@@ -37,23 +34,17 @@ public class Java25 {
         java25DemoPool.add(new CpuTimeProfilingDemo());
         // JEP 515
         java25DemoPool.add(new AheadOfTimeMethodProfiling());
-
-          // JEP 519
+        // JEP 514
+        java25DemoPool.add(new AheadOfTimeCLI()); // <- added demo
+        // JEP 519
         java25DemoPool.add(new CompactObjectHeaderDemo());
-
-        //JEP 508
+        // JEP 508
         java25DemoPool.add(new VectorApiDemo());
-
-
-        //JEP 506
+        // JEP 506
         java25DemoPool.add(new ScopedValuesDemo());
-
-
-        //JEP 502
+        // JEP 502
         java25DemoPool.add(new StableValuesDemo());
-
 
         return java25DemoPool;
     }
-
 }

--- a/src/main/java/org/javademos/java25/jep514/AheadOfTimeCLI.java
+++ b/src/main/java/org/javademos/java25/jep514/AheadOfTimeCLI.java
@@ -1,0 +1,53 @@
+package org.javademos.java25.jep514;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 25 feature **Ahead-of-Time Command-Line Ergonomics** (JEP 514)
+///
+/// JEP history:
+/// - JDK 25: [JEP 514 - Ahead-of-Time Command-Line Ergonomics](https://openjdk.org/jeps/514)
+///
+/// Further reading:
+/// - [Simplifying Java CLI with AOT Compilation](https://www.infoq.com/news/2025/05/java-25-aot-cli/)
+///
+/// This demo shows how JEP 514 improves the command-line experience for Ahead-of-Time compilation.
+/// It simulates a CLI workflow with simplified commands and helpful feedback.
+///
+/// @author Shivansh @Shivansh-22866
+public class AheadOfTimeCLI implements IDemo {
+
+    @Override
+    public void demo() {
+        info(514);
+
+        System.out.println("Starting JEP 514 - Ahead-of-Time Command-Line Ergonomics Demo...");
+        System.out.println("This demo simulates simplified 'java -AOT' usage with helpful guidance.\n");
+
+        System.out.println("Step 1: Cold run without any prior AOT compilation.");
+        simulateCLICommand("java MyApp.java");
+        
+        System.out.println("\nStep 2: Training run (simulating profiling hints for AOT).");
+        simulateCLICommand("java -AOT MyApp.java --train");
+
+        System.out.println("\nStep 3: Production run with cached AOT data applied.");
+        simulateCLICommand("java -AOT MyApp");
+
+        System.out.println("\nNOTE: This demo simulates CLI ergonomics. Actual Ahead-of-Time compilation");
+        System.out.println("requires JDK 25 support and may involve native image generation under the hood.");
+    }
+
+    /**
+     * Simulates a CLI command execution and prints a result as if it ran.
+     * @param command the CLI command to simulate
+     */
+    private void simulateCLICommand(String command) {
+        System.out.printf("Running command: %s%n", command);
+        try {
+            // Simulate some processing time
+            Thread.sleep(200);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        System.out.println("-> Success! Command executed with simplified AOT workflow.");
+    }
+}

--- a/src/main/resources/JDK25Info.json
+++ b/src/main/resources/JDK25Info.json
@@ -12,17 +12,13 @@
       "name": "JEP 470 - PEM Encodings of Cryptographic Objects (Preview)",
       "dscr": "Preview support for reading and writing PEM-encoded cryptographic objects; see PemEncodings.java"
     }
-
-    },
+  },
   {
     "jep": 519,
     "info": {
-      "name": "JEP 519 -  Compact Object Headers",
-      "dscr": "Adds a demo for JEP 519 — Class-File API, showcasing how to parse, inspect, and generate Java class files programmatically.; see CompactObjectHeaderDemo.java "
+      "name": "JEP 519 - Compact Object Headers",
+      "dscr": "Adds a demo for JEP 519 — Class-File API, showcasing how to parse, inspect, and generate Java class files programmatically; see CompactObjectHeaderDemo.java"
     }
-  }
-]
-
   },
   {
     "jep": 518,
@@ -37,14 +33,13 @@
       "name": "JEP 509 - JFR CPU-Time Profiling",
       "dscr": "Demonstrates experimental CPU-Time Profiling using JFR; see CpuTimeProfilingDemo.java"
     }
-  }
-      {
+  },
+  {
     "jep": 508,
     "info": {
       "name": "Vector API (Tenth Incubator)",
-      "dscr": "Demo: vectorized float-array addition using jdk.incubator.vector (JEP 508). Compare vector vs scalar."
+      "dscr": "Demo: vectorized float-array addition using jdk.incubator.vector (JEP 508). Compare vector vs scalar; see VectorApiDemo.java"
     }
-  
   },
   {
     "jep": 515,
@@ -52,32 +47,26 @@
       "name": "JEP 515 - Ahead-of-Time Method Profiling",
       "dscr": "Demonstrates Ahead-of-Time Method Profiling which improves warmup time; see AheadOfTimeMethodProfiling.java"
     }
-    },
-
-    
-
-    {
-  "jep": 506,
-  "info": {
-    "name": "JEP 506 - Scoped Values",
-    "dscr": "Scoped Values provide a safe, immutable alternative to thread-local variables; see ScopedValuesDemo.java"
-  }
-
-},
-{
-  "jep": 502,
-  "info": {
-    "name": "JEP 502 - Stable Values (Preview)",
-    "dscr": "Stable Values offer an immutable data abstraction for performance and safety; see StableValuesDemo.java"
-  }
-}
-
-
-
-
-
+  },
+  {
+    "jep": 514,
+    "info": {
+      "name": "JEP 514 - Ahead-of-Time Command-Line Ergonomics",
+      "dscr": "Shows simplified and ergonomic CLI commands for Ahead-of-Time compilation; see AheadOfTimeCLI.java"
+    }
+  },
+  {
+    "jep": 506,
+    "info": {
+      "name": "JEP 506 - Scoped Values",
+      "dscr": "Scoped Values provide a safe, immutable alternative to thread-local variables; see ScopedValuesDemo.java"
+    }
+  },
+  {
+    "jep": 502,
+    "info": {
+      "name": "JEP 502 - Stable Values (Preview)",
+      "dscr": "Stable Values offer an immutable data abstraction for performance and safety; see StableValuesDemo.java"
+    }
   }
 ]
-
-
-


### PR DESCRIPTION
This PR adds a new demo for JDK 25 feature JEP 514 - Ahead-of-Time Command-Line Ergonomics.

Changes included:
- Added `AheadOfTimeCLI.java` in `org.javademos.java25.jep514` package.
- Updated `Java25.java` to include the new demo in the demo list.
- Updated JSON metadata to include JEP 514 for consistent tracking.

The demo illustrates:
- Simplified 'java -AOT' command usage.
- Step-by-step simulation of cold, training, and production runs.
- Clear notes on simulated behavior versus actual AOT compilation.

This contribution follows the style and structure of existing JDK 25 demos.
