### PR TITLE
Add JEP 461 demo: Stream Gatherers (Preview) for JDK 22

### DIFF
--- a/src/main/java/org/javademos/init/Java22.java
+++ b/src/main/java/org/javademos/init/Java22.java
@@ -3,9 +3,10 @@ package org.javademos.init;
 import org.javademos.commons.IDemo;
 import org.javademos.java22.jep423.RegionPinningForG1;
 import org.javademos.java22.jep447.StatementsBeforeSuper;
-import org.javademos.java22.jep456.UnnamedPatternsAndVariablesDemo;
-import org.javademos.java22.jep464.ScopedValues;
 import org.javademos.java22.jep454.ForeignFunctionMemoryDemo;
+import org.javademos.java22.jep456.UnnamedPatternsAndVariablesDemo;
+import org.javademos.java22.jep461.StreamGatherers461;
+import org.javademos.java22.jep464.ScopedValues;
 
 import java.util.ArrayList;
 
@@ -20,11 +21,11 @@ public class Java22 {
         // feel free to comment out demos you are not interested in right now
         java22DemoPool.add(new RegionPinningForG1());
         java22DemoPool.add(new StatementsBeforeSuper());
-        java22DemoPool.add(new UnnamedPatternsAndVariablesDemo());
-        java22DemoPool.add(new ScopedValues());
         java22DemoPool.add(new ForeignFunctionMemoryDemo());
-        
+        java22DemoPool.add(new UnnamedPatternsAndVariablesDemo());
+        java22DemoPool.add(new StreamGatherers461());   // JEP 461
+        java22DemoPool.add(new ScopedValues());
+
         return java22DemoPool;
     }
-
 }

--- a/src/main/java/org/javademos/java22/jep461/StreamGatherers.java
+++ b/src/main/java/org/javademos/java22/jep461/StreamGatherers.java
@@ -1,0 +1,48 @@
+package org.javademos.java22.jep461;
+
+import org.javademos.commons.IDemo;
+
+import java.util.stream.Gatherers;
+import java.util.stream.IntStream;
+
+/**
+ * <p>
+ *   Demo for JDK 22 feature <strong>Stream Gatherers (Preview)</strong> (JEP 461).
+ * </p>
+ *
+ * <p>
+ *   Stream Gatherers introduce a new intermediate operation
+ *   {@code Stream.gather(Gatherer)} that enables custom, stateful
+ *   transformations on streams. It allows use cases like windowing,
+ *   chunking, and scanning which were previously difficult to implement
+ *   with the standard Stream API.
+ * </p>
+ *
+ * <p><strong>Example:</strong></p>
+ * <pre>{@code
+ *   var numbers = IntStream.rangeClosed(1, 10).boxed();
+ *   var windows = numbers.gather(Gatherers.windowFixed(3));
+ *   windows.forEach(System.out::println);
+ * }</pre>
+ *
+ * @see <a href="https://openjdk.org/jeps/461">JEP 461: Stream Gatherers (Preview)</a>
+ */
+public class StreamGatherers461 implements IDemo {
+    @Override
+    public void demo() {
+        info(461);
+
+        // Example 1: fixed-size windows of 3
+        var numbers = IntStream.rangeClosed(1, 10).boxed();
+        var windows = numbers.gather(Gatherers.windowFixed(3));
+        System.out.println("Fixed windows of 3:");
+        windows.forEach(window -> System.out.println("  " + window));
+
+        // Example 2: running sum using scan
+        var sums = IntStream.rangeClosed(1, 5)
+                .boxed()
+                .gather(Gatherers.scan(0, Integer::sum));
+        System.out.println("\nRunning sums:");
+        sums.forEach(sum -> System.out.println("  " + sum));
+    }
+}

--- a/src/main/java/org/javademos/java22/jep461/StreamGatherers.java
+++ b/src/main/java/org/javademos/java22/jep461/StreamGatherers.java
@@ -5,28 +5,15 @@ import org.javademos.commons.IDemo;
 import java.util.stream.Gatherers;
 import java.util.stream.IntStream;
 
-/**
- * <p>
- *   Demo for JDK 22 feature <strong>Stream Gatherers (Preview)</strong> (JEP 461).
- * </p>
- *
- * <p>
- *   Stream Gatherers introduce a new intermediate operation
- *   {@code Stream.gather(Gatherer)} that enables custom, stateful
- *   transformations on streams. It allows use cases like windowing,
- *   chunking, and scanning which were previously difficult to implement
- *   with the standard Stream API.
- * </p>
- *
- * <p><strong>Example:</strong></p>
- * <pre>{@code
- *   var numbers = IntStream.rangeClosed(1, 10).boxed();
- *   var windows = numbers.gather(Gatherers.windowFixed(3));
- *   windows.forEach(System.out::println);
- * }</pre>
- *
- * @see <a href="https://openjdk.org/jeps/461">JEP 461: Stream Gatherers (Preview)</a>
- */
+/// Demo for JDK 22 feature **Stream Gatherers (Preview)** (JEP 461)
+///
+/// JEP history:
+/// - JDK 22: [JEP 461 - Stream Gatherers (Preview)](https://openjdk.org/jeps/461)
+///
+/// Further reading:
+/// - [Stream Gatherers in Java](https://openjdk.org/jeps/461)
+///
+/// @author shepherdking67
 public class StreamGatherers461 implements IDemo {
     @Override
     public void demo() {

--- a/src/main/resources/JDK22Info.json
+++ b/src/main/resources/JDK22Info.json
@@ -14,16 +14,24 @@
     }
   },
   {
-    "jep": 464,
-    "info": {
-      "name": "JEP 464 - Scoped Values (Second Preview)",
-      "dscr": "Implementation moved into `org.javademos.java23.jep481.ScopedValues` (JEP 481)"
-    }
-  }, {
     "jep": 454,
     "info": {
       "name": "JEP 454 - Foreign Function & Memory API",
       "dscr": "Demonstrates calling C library function 'strlen' using Java's Foreign Function & Memory API."
+    }
+  },
+  {
+    "jep": 461,
+    "info": {
+      "name": "JEP 461 - Stream Gatherers (Preview)",
+      "dscr": "See StreamGatherers461 class for further info"
+    }
+  },
+  {
+    "jep": 464,
+    "info": {
+      "name": "JEP 464 - Scoped Values (Second Preview)",
+      "dscr": "Implementation moved into `org.javademos.java23.jep481.ScopedValues` (JEP 481)"
     }
   }
 ]


### PR DESCRIPTION
This PR implements the demo for JEP 461: Stream Gatherers (Preview) in JDK 22.

Changes made:

Added StreamGatherers461.java with a working demo using custom and built-in gatherers.

Updated JDK22Info.json to include JEP 461 entry.

Updated Java22.java to register the demo in the init file.

Closes #20