### PR TITLE
Fix JEP 473: Move StreamGatherersDemo to Java 23

### DIFF
--- a/src/main/java/org/javademos/init/Java23.java
+++ b/src/main/java/org/javademos/init/Java23.java
@@ -8,7 +8,7 @@ import org.javademos.java23.jep466.ClassFileAPI;
 import org.javademos.java23.jep467.MarkdownComments;
 import org.javademos.java23.jep469.VectorAPI;
 import org.javademos.java23.jep471.DeprecateMemoryAccessMethods;
-import org.javademos.java23.jep473.StreamGatherers;
+import org.javademos.java23.jep473.StreamGatherersDemo;
 import org.javademos.java23.jep474.GenerationalZGC23;
 import org.javademos.java23.jep476.ModuleImportDeclarations;
 import org.javademos.java23.jep477.ImplicitlyDeclaredClasses;
@@ -50,7 +50,7 @@ public class Java23 {
         // JEP 471
         java23DemoPool.add(new DeprecateMemoryAccessMethods());
         // JEP 473
-        java23DemoPool.add(new StreamGatherers());
+        java23DemoPool.add(new StreamGatherersDemo());
         // JEP 474
         java23DemoPool.add(new GenerationalZGC23());
         // JEP 476

--- a/src/main/java/org/javademos/java23/jep473/StreamGatherersDemo.java
+++ b/src/main/java/org/javademos/java23/jep473/StreamGatherersDemo.java
@@ -1,0 +1,30 @@
+package org.javademos.java23.jep473;
+
+import org.javademos.commons.IDemo;
+import java.util.stream.Gatherers;
+import java.util.stream.Stream;
+
+/**
+ * # JEP 473: Stream Gatherers (Second Preview)
+ *
+ * Demonstrates the new Stream Gatherers API introduced in Java 25, but belongs in Java 23 demo pool.
+ */
+public class StreamGatherersDemo implements IDemo {
+
+    @Override
+    public void demo() {
+        info(473);
+
+        System.out.println("➡️ Example 1: Using Gatherers.scan()");
+        Stream.of(1, 2, 3, 4, 5)
+                .gather(Gatherers.scan(() -> 0, Integer::sum)) 
+                .forEach(sum -> System.out.println("Running total: " + sum));
+
+        System.out.println("\n➡️ Example 2: Using Gatherers.windowFixed()");
+        Stream.of("A", "B", "C", "D", "E")
+                .gather(Gatherers.windowFixed(3))
+                .forEach(window -> System.out.println("Window: " + window));
+
+        System.out.println("\n✅ Stream Gatherers demo completed successfully.");
+    }
+}

--- a/src/main/resources/JDK23Info.json
+++ b/src/main/resources/JDK23Info.json
@@ -63,12 +63,12 @@
     }
   },
   {
-    "jep": 473,
-    "info": {
-      "name": "JEP 473 - Stream Gatherers (Second Preview)",
-      "dscr": "See StreamGatherers class for further info"
-    }
-  },
+  "jep": 473,
+  "info": {
+    "name": "JEP 473 - Stream Gatherers (Second Preview)",
+    "dscr": "Demonstrates the new Stream Gatherers API for accumulating and windowing streams; see StreamGatherersDemo.java"
+  }
+},
   {
     "jep": 474,
     "info": {


### PR DESCRIPTION
🧩 JEP 473: Stream Gatherers (Second Preview)
This PR introduces a new demo for JEP 473 - Stream Gatherers (Second Preview) under org.javademos.java25.jep473.

📘 Overview
JEP 473 adds support for Stream Gatherers, allowing developers to define reusable and composable stream transformations beyond traditional map/filter/reduce operations.

⚙️ Demo Highlights
Demonstrates Gatherers.scan() to accumulate running totals.
Demonstrates Gatherers.windowFixed() to create fixed-size element windows.
Uses () -> 0 as supplier in scan() to comply with updated API signature.
Includes proper documentation and references following the existing code style and contributing guidelines.