### PR TITLE
Add demo for JEP 486 - Permanently Disable the Security Manager (JDK 24)

### DIFF
--- a/src/main/java/org/javademos/init/Java24.java
+++ b/src/main/java/org/javademos/init/Java24.java
@@ -16,10 +16,10 @@ public class Java24 {
         var java24DemoPool = new ArrayList<IDemo>();
 
         // feel free to comment out demos you are not interested in right now
-        
+
         // JEP 485
         java24DemoPool.add(new StreamGatherers());
-        
+
         // JEP 493
         java24DemoPool.add(new LinkingRunTimeImages493());
 

--- a/src/main/java/org/javademos/init/Java24.java
+++ b/src/main/java/org/javademos/init/Java24.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import org.javademos.commons.IDemo;
 import org.javademos.java24.jep485.StreamGatherers;
 import org.javademos.java24.jep493.LinkingRunTimeImages493;
+import org.javademos.java24.jep486.DisableSecurityManager;
 
 public class Java24 {
 
@@ -21,6 +22,9 @@ public class Java24 {
         
         // JEP 493
         java24DemoPool.add(new LinkingRunTimeImages493());
+
+        // JEP 486
+        java24DemoPool.add(new DisableSecurityManager());
 
         return java24DemoPool;
     }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -5,34 +5,29 @@ import org.javademos.commons.IDemo;
 /**
  * JEP 486 - Permanently Disable the Security Manager
  *
- * Demonstrates that the Security Manager has been permanently disabled.
+ * The Security Manager API has been permanently removed.
+ * This demo serves as an educational placeholder, explaining
+ * that attempts to use or set a SecurityManager are no longer supported.
  */
 public class DisableSecurityManager implements IDemo {
 
     @Override
-    public int runDemo() {
-        System.out.println("Running JEP 486 - Permanently Disable the Security Manager demo...");
-
+    public void demo() {
+        // The Security Manager was deprecated for removal in earlier releases
+        // and is now permanently disabled as of JDK 24.
+        //
+        // Any attempt to call System.setSecurityManager(...) results in an
+        // UnsupportedOperationException.
+        
         try {
-            // Attempt to set a SecurityManager
-            System.setSecurityManager(new SecurityManager());
-            System.out.println("SecurityManager successfully set (unexpected in JDK 24/25).");
+            System.setSecurityManager(new SecurityManager()); // this is removed
         } catch (UnsupportedOperationException e) {
-            System.out.println("Expected: Security Manager cannot be set. It is permanently disabled.");
-        } catch (Exception e) {
-            System.out.println("Caught exception: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+            System.out.println("SecurityManager is permanently disabled: " + e);
         }
-
-        return 0;
     }
 
     @Override
-    public String getName() {
+    public String toString() {
         return "JEP 486 - Permanently Disable the Security Manager";
-    }
-
-    @Override
-    public String getDescription() {
-        return "Demonstrates that the Security Manager has been permanently disabled in JDK 24/25.";
     }
 }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -13,21 +13,18 @@ public class DisableSecurityManager implements IDemo {
 
     @Override
     public void demo() {
+        // JEP reference info
+        info(486);
+
         // The Security Manager was deprecated for removal in earlier releases
         // and is now permanently disabled as of JDK 24.
         //
         // Any attempt to call System.setSecurityManager(...) results in an
         // UnsupportedOperationException.
-        
         try {
             System.setSecurityManager(new SecurityManager()); // this is removed
         } catch (UnsupportedOperationException e) {
             System.out.println("SecurityManager is permanently disabled: " + e);
         }
-    }
-
-    @Override
-    public String toString() {
-        return "JEP 486 - Permanently Disable the Security Manager";
     }
 }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -2,13 +2,16 @@ package org.javademos.java24.jep486;
 
 import org.javademos.commons.IDemo;
 
-/**
- * JEP 486 - Permanently Disable the Security Manager
- *
- * The Security Manager API has been permanently removed.
- * This demo serves as an educational placeholder, explaining
- * that attempts to use or set a SecurityManager are no longer supported.
- */
+/// Demo for JDK 24 feature **Permanently Disable the Security Manager** (JEP 486)
+///
+/// JEP history:
+/// - JDK 24: [JEP 486 - Permanently Disable the Security Manager](https://openjdk.org/jeps/486)
+///
+/// Further reading:
+/// - [JEP 411 (Deprecate the Security Manager)](https://openjdk.org/jeps/411)
+/// - [JEP 486 - Details](https://openjdk.org/jeps/486)
+///
+/// @author shepherdking67
 public class DisableSecurityManager implements IDemo {
 
     @Override
@@ -22,7 +25,7 @@ public class DisableSecurityManager implements IDemo {
         // Any attempt to call System.setSecurityManager(...) results in an
         // UnsupportedOperationException.
         try {
-            System.setSecurityManager(new SecurityManager()); // this is removed
+            System.setSecurityManager(new SecurityManager()); // removed in JDK 24+
         } catch (UnsupportedOperationException e) {
             System.out.println("SecurityManager is permanently disabled: " + e);
         }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -1,0 +1,38 @@
+package org.javademos.java24.jep486;
+
+import org.javademos.commons.IDemo;
+
+/**
+ * JEP 486 - Permanently Disable the Security Manager
+ *
+ * Demonstrates that the Security Manager has been permanently disabled.
+ */
+public class DisableSecurityManager implements IDemo {
+
+    @Override
+    public int runDemo() {
+        System.out.println("Running JEP 486 - Permanently Disable the Security Manager demo...");
+
+        try {
+            // Attempt to set a SecurityManager
+            System.setSecurityManager(new SecurityManager());
+            System.out.println("SecurityManager successfully set (unexpected in JDK 24/25).");
+        } catch (UnsupportedOperationException e) {
+            System.out.println("Expected: Security Manager cannot be set. It is permanently disabled.");
+        } catch (Exception e) {
+            System.out.println("Caught exception: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String getName() {
+        return "JEP 486 - Permanently Disable the Security Manager";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Demonstrates that the Security Manager has been permanently disabled in JDK 24/25.";
+    }
+}

--- a/src/main/resources/JDK24Info.json
+++ b/src/main/resources/JDK24Info.json
@@ -7,17 +7,17 @@
     }
   },
   {
-    "jep": 486,
-    "info": {
-      "name": "JEP 486 - Permanently Disable the Security Manager",
-      "dscr": "Remove the Security Manager API from the JDK. This finalizes its deprecation, ensuring developers transition to modern security practices and eliminating legacy maintenance overhead."
-    }
-  },
-  {
     "jep": 493,
     "info": {
       "name": "JEP 493 - Linking Run-Time Images without JMODs",
       "dscr": "Simplifies jlink by removing the need for JMOD files. Developers can now link custom runtime images directly from modular JARs, streamlining the build process."
+    }
+  },
+  {
+    "jep": 486,
+    "info": {
+      "name": "JEP 486 - Permanently Disable the Security Manager",
+      "dscr": "The Security Manager API, deprecated for removal in earlier releases, has now been permanently disabled. Any attempt to set a Security Manager will result in an UnsupportedOperationException."
     }
   }
 ]

--- a/src/main/resources/JDK24Info.json
+++ b/src/main/resources/JDK24Info.json
@@ -7,6 +7,13 @@
     }
   },
   {
+    "jep": 486,
+    "info": {
+      "name": "JEP 486 - Permanently Disable the Security Manager",
+      "dscr": "Remove the Security Manager API from the JDK. This finalizes its deprecation, ensuring developers transition to modern security practices and eliminating legacy maintenance overhead."
+    }
+  },
+  {
     "jep": 493,
     "info": {
       "name": "JEP 493 - Linking Run-Time Images without JMODs",


### PR DESCRIPTION
…hanges)This PR adds a demo for **JEP 486 - Permanently Disable the Security Manager** as part of the Java 24 features.

Changes included:
- Added `DisableSecurityManager.java` under `src/main/java/org/javademos/java24/jep486/`.
- Updated `Java24.java` to register the new demo.
- Extended `JDK24Info.json` with JEP 486 metadata.

Build & Verification:
- Successfully compiled with `mvn clean install` using JDK 25 (as the project runs under JDK 25).
- Verified that the demo is correctly included in the Java 24 demo pool.

Notes:
- Since the Security Manager has been permanently removed, the demo focuses on explanatory comments rather than runtime code execution, in line with project guidelines.


Closes #101 
