### PR TITLE
Add demo for JEP 512: Compact Source Files and Instance Main Methods

### DIFF
--- a/src/main/java/org/javademos/init/Java24.java
+++ b/src/main/java/org/javademos/init/Java24.java
@@ -16,10 +16,10 @@ public class Java24 {
         var java24DemoPool = new ArrayList<IDemo>();
 
         // feel free to comment out demos you are not interested in right now
-        
+
         // JEP 485
         java24DemoPool.add(new StreamGatherers());
-        
+
         // JEP 493
         java24DemoPool.add(new LinkingRunTimeImages493());
 

--- a/src/main/java/org/javademos/init/Java24.java
+++ b/src/main/java/org/javademos/init/Java24.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import org.javademos.commons.IDemo;
 import org.javademos.java24.jep485.StreamGatherers;
 import org.javademos.java24.jep493.LinkingRunTimeImages493;
+import org.javademos.java24.jep486.DisableSecurityManager;
 
 public class Java24 {
 
@@ -21,6 +22,9 @@ public class Java24 {
         
         // JEP 493
         java24DemoPool.add(new LinkingRunTimeImages493());
+
+        // JEP 486
+        java24DemoPool.add(new DisableSecurityManager());
 
         return java24DemoPool;
     }

--- a/src/main/java/org/javademos/init/Java25.java
+++ b/src/main/java/org/javademos/init/Java25.java
@@ -11,6 +11,7 @@ import org.javademos.java25.jep508.VectorApiDemo;
 import org.javademos.java25.jep509.CpuTimeProfilingDemo;
 import org.javademos.java25.jep510.KeyDerivationFunctionDemo;
 import org.javademos.java25.jep511.ModuleImportDeclarationsDemo;
+import org.javademos.java25.jep512.CompactSourceAndInstanceMain;
 import org.javademos.java25.jep513.FlexibleConstructorBodiesDemo;
 import org.javademos.java25.jep514.AheadOfTimeCLIDemo;
 import org.javademos.java25.jep515.AheadOfTimeMethodProfilingDemo;
@@ -27,11 +28,12 @@ public class Java25 {
      */
     public static ArrayList<IDemo> getDemos() {
         var java25DemoPool = new ArrayList<IDemo>();
+
         // JEP 470
         java25DemoPool.add(new PemEncodingsDemo());
         // JEP 502
         java25DemoPool.add(new StableValuesDemo());
-        //JEP 503
+        // JEP 503
         java25DemoPool.add(new Remove32BitX86Demo());
         // JEP 505
         java25DemoPool.add(new StructuredConcurrencyDemo());
@@ -47,6 +49,8 @@ public class Java25 {
         java25DemoPool.add(new KeyDerivationFunctionDemo());
         // JEP 511
         java25DemoPool.add(new ModuleImportDeclarationsDemo());
+        // JEP 512
+        java25DemoPool.add(new CompactSourceAndInstanceMain());
         // JEP 513
         java25DemoPool.add(new FlexibleConstructorBodiesDemo());
         // JEP 514
@@ -57,7 +61,6 @@ public class Java25 {
         java25DemoPool.add(new JFRCooperativeSamplingDemo());
         // JEP 519
         java25DemoPool.add(new CompactObjectHeaderDemo());
-
         // JEP 520
         java25DemoPool.add(new Jep520MethodTracingDemo());
 

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -5,34 +5,29 @@ import org.javademos.commons.IDemo;
 /**
  * JEP 486 - Permanently Disable the Security Manager
  *
- * Demonstrates that the Security Manager has been permanently disabled.
+ * The Security Manager API has been permanently removed.
+ * This demo serves as an educational placeholder, explaining
+ * that attempts to use or set a SecurityManager are no longer supported.
  */
 public class DisableSecurityManager implements IDemo {
 
     @Override
-    public int runDemo() {
-        System.out.println("Running JEP 486 - Permanently Disable the Security Manager demo...");
-
+    public void demo() {
+        // The Security Manager was deprecated for removal in earlier releases
+        // and is now permanently disabled as of JDK 24.
+        //
+        // Any attempt to call System.setSecurityManager(...) results in an
+        // UnsupportedOperationException.
+        
         try {
-            // Attempt to set a SecurityManager
-            System.setSecurityManager(new SecurityManager());
-            System.out.println("SecurityManager successfully set (unexpected in JDK 24/25).");
+            System.setSecurityManager(new SecurityManager()); // this is removed
         } catch (UnsupportedOperationException e) {
-            System.out.println("Expected: Security Manager cannot be set. It is permanently disabled.");
-        } catch (Exception e) {
-            System.out.println("Caught exception: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+            System.out.println("SecurityManager is permanently disabled: " + e);
         }
-
-        return 0;
     }
 
     @Override
-    public String getName() {
+    public String toString() {
         return "JEP 486 - Permanently Disable the Security Manager";
-    }
-
-    @Override
-    public String getDescription() {
-        return "Demonstrates that the Security Manager has been permanently disabled in JDK 24/25.";
     }
 }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -13,21 +13,18 @@ public class DisableSecurityManager implements IDemo {
 
     @Override
     public void demo() {
+        // JEP reference info
+        info(486);
+
         // The Security Manager was deprecated for removal in earlier releases
         // and is now permanently disabled as of JDK 24.
         //
         // Any attempt to call System.setSecurityManager(...) results in an
         // UnsupportedOperationException.
-        
         try {
             System.setSecurityManager(new SecurityManager()); // this is removed
         } catch (UnsupportedOperationException e) {
             System.out.println("SecurityManager is permanently disabled: " + e);
         }
-    }
-
-    @Override
-    public String toString() {
-        return "JEP 486 - Permanently Disable the Security Manager";
     }
 }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -2,13 +2,16 @@ package org.javademos.java24.jep486;
 
 import org.javademos.commons.IDemo;
 
-/**
- * JEP 486 - Permanently Disable the Security Manager
- *
- * The Security Manager API has been permanently removed.
- * This demo serves as an educational placeholder, explaining
- * that attempts to use or set a SecurityManager are no longer supported.
- */
+/// Demo for JDK 24 feature **Permanently Disable the Security Manager** (JEP 486)
+///
+/// JEP history:
+/// - JDK 24: [JEP 486 - Permanently Disable the Security Manager](https://openjdk.org/jeps/486)
+///
+/// Further reading:
+/// - [JEP 411 (Deprecate the Security Manager)](https://openjdk.org/jeps/411)
+/// - [JEP 486 - Details](https://openjdk.org/jeps/486)
+///
+/// @author shepherdking67
 public class DisableSecurityManager implements IDemo {
 
     @Override
@@ -22,7 +25,7 @@ public class DisableSecurityManager implements IDemo {
         // Any attempt to call System.setSecurityManager(...) results in an
         // UnsupportedOperationException.
         try {
-            System.setSecurityManager(new SecurityManager()); // this is removed
+            System.setSecurityManager(new SecurityManager()); // removed in JDK 24+
         } catch (UnsupportedOperationException e) {
             System.out.println("SecurityManager is permanently disabled: " + e);
         }

--- a/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
+++ b/src/main/java/org/javademos/java24/jep486/DisableSecurityManager.java
@@ -1,0 +1,38 @@
+package org.javademos.java24.jep486;
+
+import org.javademos.commons.IDemo;
+
+/**
+ * JEP 486 - Permanently Disable the Security Manager
+ *
+ * Demonstrates that the Security Manager has been permanently disabled.
+ */
+public class DisableSecurityManager implements IDemo {
+
+    @Override
+    public int runDemo() {
+        System.out.println("Running JEP 486 - Permanently Disable the Security Manager demo...");
+
+        try {
+            // Attempt to set a SecurityManager
+            System.setSecurityManager(new SecurityManager());
+            System.out.println("SecurityManager successfully set (unexpected in JDK 24/25).");
+        } catch (UnsupportedOperationException e) {
+            System.out.println("Expected: Security Manager cannot be set. It is permanently disabled.");
+        } catch (Exception e) {
+            System.out.println("Caught exception: " + e.getClass().getSimpleName() + " - " + e.getMessage());
+        }
+
+        return 0;
+    }
+
+    @Override
+    public String getName() {
+        return "JEP 486 - Permanently Disable the Security Manager";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Demonstrates that the Security Manager has been permanently disabled in JDK 24/25.";
+    }
+}

--- a/src/main/java/org/javademos/java25/jep512/CompactSourceAndInstanceMain.java
+++ b/src/main/java/org/javademos/java25/jep512/CompactSourceAndInstanceMain.java
@@ -1,0 +1,28 @@
+package org.javademos.java25.jep512;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 25 feature **Compact Source Files and Instance Main Methods** (JEP 512)
+///
+/// JEP history:
+/// - JDK 25: [JEP 512 - Compact Source Files and Instance Main Methods](https://openjdk.org/jeps/512)
+///
+/// Further reading:
+/// - [Inside Java: JEP 512 Overview](https://openjdk.org/jeps/512)
+///
+/// @author shepherdking67
+public class CompactSourceAndInstanceMain implements IDemo {
+
+    @Override
+    public void demo() {
+        info(512);
+
+        System.out.println("Compact Source Files allow simpler, smaller Java source files with default settings.");
+        System.out.println("Instance main methods let you define a main method without using static.");
+    }
+
+    // Example of instance main (JEP 512 feature)
+    void main(String[] args) {
+        new CompactSourceAndInstanceMain().demo();
+    }
+}

--- a/src/main/resources/JDK24Info.json
+++ b/src/main/resources/JDK24Info.json
@@ -7,17 +7,17 @@
     }
   },
   {
-    "jep": 486,
-    "info": {
-      "name": "JEP 486 - Permanently Disable the Security Manager",
-      "dscr": "Remove the Security Manager API from the JDK. This finalizes its deprecation, ensuring developers transition to modern security practices and eliminating legacy maintenance overhead."
-    }
-  },
-  {
     "jep": 493,
     "info": {
       "name": "JEP 493 - Linking Run-Time Images without JMODs",
       "dscr": "Simplifies jlink by removing the need for JMOD files. Developers can now link custom runtime images directly from modular JARs, streamlining the build process."
+    }
+  },
+  {
+    "jep": 486,
+    "info": {
+      "name": "JEP 486 - Permanently Disable the Security Manager",
+      "dscr": "The Security Manager API, deprecated for removal in earlier releases, has now been permanently disabled. Any attempt to set a Security Manager will result in an UnsupportedOperationException."
     }
   }
 ]

--- a/src/main/resources/JDK24Info.json
+++ b/src/main/resources/JDK24Info.json
@@ -7,6 +7,13 @@
     }
   },
   {
+    "jep": 486,
+    "info": {
+      "name": "JEP 486 - Permanently Disable the Security Manager",
+      "dscr": "Remove the Security Manager API from the JDK. This finalizes its deprecation, ensuring developers transition to modern security practices and eliminating legacy maintenance overhead."
+    }
+  },
+  {
     "jep": 493,
     "info": {
       "name": "JEP 493 - Linking Run-Time Images without JMODs",

--- a/src/main/resources/JDK25Info.json
+++ b/src/main/resources/JDK25Info.json
@@ -70,6 +70,13 @@
     }
   },
   {
+  "jep": 512,
+  "info": {
+    "name": "JEP 512 - Compact Source Files and Instance Main Methods",
+    "dscr": "Introduces simplified source files that allow top-level code without explicit class declarations and enable instance main methods."
+  }
+},
+  {
     "jep": 513,
     "info": {
       "name": "JEP 513 - Flexible Constructor Bodies",


### PR DESCRIPTION
Adds a new demo showcasing JEP 512 — Compact Source Files and Instance Main Methods, introduced in JDK 25.

Details:

Added new demo class CompactSourceAndInstanceMain.java under org.javademos.java25.jep512

Updated Java25.java to register the new demo

Added JEP 512 entry to JDK25Info.json

JEP Reference:
🔗 [JEP 512 – Compact Source Files and Instance Main Methods](https://openjdk.org/jeps/512)

Author: @shepherdking67

closes #40 