### PR TITLE
feat(java17): add JEP 306 – Restore Always-Strict Floating-Point Sema…

### DIFF
--- a/src/main/java/org/javademos/init/Java17.java
+++ b/src/main/java/org/javademos/init/Java17.java
@@ -1,6 +1,7 @@
 package org.javademos.init;
 
 import org.javademos.commons.IDemo;
+import org.javademos.java17.jep306.RestoreAlwaysStrictFloatingPointSemanticsDemo;
 import org.javademos.java17.jep403.StronglyEncapsulateInternalsDemo;
 import org.javademos.java17.jep406.PatternMatchingForSwitchPreview;
 import org.javademos.java17.jep411.DeprecateSecurityManagerDemo;
@@ -28,6 +29,8 @@ public class Java17 {
         var java17DemoPool = new ArrayList<IDemo>();
 
         // feel free to comment out demos you are not interested in right now
+        // JEP 306
+        java17DemoPool.add(new RestoreAlwaysStrictFloatingPointSemanticsDemo());
         // JEP 403
         java17DemoPool.add(new StronglyEncapsulateInternalsDemo());
         // JEP 406

--- a/src/main/java/org/javademos/java17/jep306/RestoreAlwaysStrictFloatingPointSemanticsDemo.java
+++ b/src/main/java/org/javademos/java17/jep306/RestoreAlwaysStrictFloatingPointSemanticsDemo.java
@@ -1,0 +1,47 @@
+package org.javademos.java17.jep306;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 17 feature JEP 306 - Restore Always-Strict Floating-Point Semantics.
+///
+/// JEP history:
+/// - JDK 17: [JEP 306 - Restore Always-Strict Floating-Point Semantics](https://openjdk.org/jeps/306)
+///
+/// Further reading:
+/// - [Restore Always-Strict Floating-Point Semantics](https://openjdk.org/jeps/306)
+///
+/// @author Alexander Schneider @ab-schneider
+public class RestoreAlwaysStrictFloatingPointSemanticsDemo implements IDemo {
+    @Override
+    public void demo() {
+        info(306);
+
+        System.out.println("Use of 'strictfp' modifier will produce a compile time warning: ");
+        System.out.println("as of release 17, all floating-point expressions are evaluated strictly and 'strictfp' is not required");
+
+        // Before JDK 17, the default floating-point evaluation could keep wider intermediates (e.g., x87 80-bit).
+        // Marking code with 'strictfp' modifier forced strict IEEE-754 evaluation,
+        // avoiding those extended intermediates. As a result, the same program could produce
+        // bit-different results across machines/JVMs if it did NOT use 'strictfp'.
+        //
+        // Since JDK 17, all floating-point expressions are strict by default,
+        // so adding 'strictfp' no longer changes numerical results. If you *do* write 'strictfp',
+        // javac will warn it's unnecessary when compiled
+
+        compute();
+    }
+
+    // Before JDK 17 to use strict floating-point instead of default 'strictfp' modifier was necessary
+    //
+    // public strictfp double strictCompute() {
+    //    ...
+    // }
+
+    public double compute() {
+        var s = 0.0;
+        for (int i = 0; i < 1_000; i++) {
+            s += Math.sin(i);
+        }
+        return s;
+    }
+}

--- a/src/main/resources/JDK17Info.json
+++ b/src/main/resources/JDK17Info.json
@@ -6,6 +6,13 @@
    }
  },
   {
+    "jep": 306,
+    "info": {
+      "name": "JEP 306 - Restore Always-Strict Floating-Point Semantics",
+      "dscr": "Make all floating-point operations consistently strict, removing the difference between strictfp and default modes."
+    }
+  },
+  {
     "jep": 406,
     "info": {
       "name": "JEP 406 - Pattern Matching for switch (Preview)",


### PR DESCRIPTION
closes https://github.com/AloisSeckar/demos-java/issues/220.

changes implemented

- added org/javademos/java17/jep306/RestoreAlwaysStrictFloatingPointSemanticsDemo.java
- updated org/javademos/init/Java17.java to include the new demo
- updated src/main/resources/JDK17Info.json with JEP 306 info

