### PR TITLE
Add demo for JEP 361 - Switch Expressions (Java 14) with JEP 325 & 354 links

### DIFF
--- a/src/main/java/org/javademos/init/Java12DemoLoader.java
+++ b/src/main/java/org/javademos/init/Java12DemoLoader.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.javademos.commons.IDemo;
 import org.javademos.commons.IDemoLoader;
+import org.javademos.java12.jep325.SwitchExpressionsPreview;
 import org.javademos.java12.jep334.ConstantsAPIDemo;
 
 /**
@@ -13,6 +14,8 @@ public class Java12DemoLoader implements IDemoLoader {
     
     @Override
     public void loadDemos(Map<Integer, IDemo> demos) {
+        // JEP 325
+        demos.put(325, new SwitchExpressionsPreview());
         // JEP 334
         demos.put(334, new ConstantsAPIDemo());
     }

--- a/src/main/java/org/javademos/init/Java13DemoLoader.java
+++ b/src/main/java/org/javademos/init/Java13DemoLoader.java
@@ -1,10 +1,10 @@
 package org.javademos.init;
 
+import java.util.Map;
+
 import org.javademos.commons.IDemo;
 import org.javademos.commons.IDemoLoader;
-import org.javademos.java14.jep370.ForeignMemoryAccessDemo;
-
-import java.util.Map;
+import org.javademos.java13.jep354.SwitchExpressionsSecondPreview;
 
 /**
  * Loads demos for Java 13.
@@ -13,8 +13,7 @@ public class Java13DemoLoader implements IDemoLoader {
     
     @Override
     public void loadDemos(Map<Integer, IDemo> demos) {
-        //TODO add demos for java 13
-
-        //demos.put(123, new FutureDemo());
+        // JEP 354
+        demos.put(354, new SwitchExpressionsSecondPreview());
     }
 }

--- a/src/main/java/org/javademos/init/Java14DemoLoader.java
+++ b/src/main/java/org/javademos/init/Java14DemoLoader.java
@@ -1,12 +1,13 @@
 package org.javademos.init;
 
+import java.util.Map;
+
 import org.javademos.commons.IDemo;
 import org.javademos.commons.IDemoLoader;
 import org.javademos.java14.jep305.InstanceofPatternMatchingPreview;
 import org.javademos.java14.jep359.RecordsPreviewDemo;
+import org.javademos.java14.jep361.SwitchExpressionsDemo;
 import org.javademos.java14.jep370.ForeignMemoryAccessDemo;
-
-import java.util.Map;
 
 /**
  * Loads demos for Java 14.
@@ -17,6 +18,7 @@ public class Java14DemoLoader implements IDemoLoader {
     public void loadDemos(Map<Integer, IDemo> demos) {
         demos.put(305, new InstanceofPatternMatchingPreview());
         demos.put(359, new RecordsPreviewDemo());
+        demos.put(361, new SwitchExpressionsDemo());
         demos.put(370, new ForeignMemoryAccessDemo());
     }
 }

--- a/src/main/java/org/javademos/java12/jep325/SwitchExpressionsPreview.java
+++ b/src/main/java/org/javademos/java12/jep325/SwitchExpressionsPreview.java
@@ -1,0 +1,21 @@
+package org.javademos.java12.jep325;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 12 feature JEP 325 - Switch Expressions (Preview).
+///
+/// This was the first preview of switch expressions, introducing the arrow label syntax
+/// and the ability to use switch as an expression. In this preview, values were returned
+/// using `break <value>`, which was later changed to `yield <value>` in JEP 354.
+///
+/// The feature was finalized in JDK 14 by JEP 361.
+/// @see org.javademos.java13.jep354.SwitchExpressionsSecondPreview
+/// @see org.javademos.java14.jep361.SwitchExpressionsDemo
+///
+/// @author Abhineshhh
+public class SwitchExpressionsPreview implements IDemo {
+    @Override
+    public void demo() {
+        info(325);
+    }
+}

--- a/src/main/java/org/javademos/java13/jep354/SwitchExpressionsSecondPreview.java
+++ b/src/main/java/org/javademos/java13/jep354/SwitchExpressionsSecondPreview.java
@@ -1,0 +1,21 @@
+package org.javademos.java13.jep354;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 13 feature JEP 354 - Switch Expressions (Second Preview).
+///
+/// This was the second preview of switch expressions. The main change from JEP 325
+/// was replacing the `break` statement with the new `yield` statement for returning
+/// values from switch expressions.
+///
+/// The feature was finalized in JDK 14 by JEP 361.
+/// @see org.javademos.java12.jep325.SwitchExpressionsPreview
+/// @see org.javademos.java14.jep361.SwitchExpressionsDemo
+///
+/// @author Abhineshhh
+public class SwitchExpressionsSecondPreview implements IDemo {
+    @Override
+    public void demo() {
+        info(354);
+    }
+}

--- a/src/main/java/org/javademos/java14/jep361/SwitchExpressionsDemo.java
+++ b/src/main/java/org/javademos/java14/jep361/SwitchExpressionsDemo.java
@@ -1,0 +1,182 @@
+package org.javademos.java14.jep361;
+
+import org.javademos.commons.IDemo;
+
+/// Demo for JDK 14 feature JEP 361 - Switch Expressions.
+///
+/// Switch expressions extend switch to be used as either a statement or an expression,
+/// with both traditional "case ... :" and new "case ... ->" labels.
+/// This was a preview feature in JDK 12 (JEP 325) and JDK 13 (JEP 354), and became final in JDK 14.
+///
+/// Key features demonstrated:
+/// - Arrow labels (case ... ->)
+/// - Switch expressions (assign values directly)
+/// - Yield statement for complex blocks
+/// - Exhaustiveness checking
+/// - Multiple constants per case
+///
+/// @see org.javademos.java12.jep325.SwitchExpressionsPreview
+/// @see org.javademos.java13.jep354.SwitchExpressionsSecondPreview
+/// @author Abhineshhh
+public class SwitchExpressionsDemo implements IDemo {
+    
+    @Override
+    public void demo() {
+        info(361);
+        
+        System.out.println("=== Traditional Switch vs Arrow Labels ===");
+        demonstrateArrowLabels();
+        
+        System.out.println("\n=== Switch as Expression ===");
+        demonstrateSwitchExpression();
+        
+        System.out.println("\n=== Yield Statement ===");
+        demonstrateYieldStatement();
+        
+        System.out.println("\n=== Multiple Constants per Case ===");
+        demonstrateMultipleConstants();
+        
+        System.out.println("\n=== Exhaustiveness with Enums ===");
+        demonstrateExhaustiveness();
+    }
+    
+    /// Demonstrates arrow labels without fall-through
+    private void demonstrateArrowLabels() {
+        int day = 3;
+        
+        // Traditional switch (verbose with break statements)
+        System.out.println("Traditional switch:");
+        switch (day) {
+            case 1:
+            case 2:
+            case 3:
+                System.out.println("  Beginning of the week");
+                break;
+            case 4:
+            case 5:
+                System.out.println("  Middle of the week");
+                break;
+            case 6:
+            case 7:
+                System.out.println("  Weekend");
+                break;
+            default:
+                System.out.println("  Invalid day");
+                break;
+        }
+        
+        // Arrow labels (concise, no fall-through)
+        System.out.println("Arrow label switch:");
+        switch (day) {
+            case 1, 2, 3 -> System.out.println("  Beginning of the week");
+            case 4, 5    -> System.out.println("  Middle of the week");
+            case 6, 7    -> System.out.println("  Weekend");
+            default      -> System.out.println("  Invalid day");
+        }
+    }
+    
+    /// Demonstrates switch as an expression
+    private void demonstrateSwitchExpression() {
+        Day day = Day.WEDNESDAY;
+        
+        // Old way: using a variable and assigning in each case
+        int numLettersOld;
+        switch (day) {
+            case MONDAY:
+            case FRIDAY:
+            case SUNDAY:
+                numLettersOld = 6;
+                break;
+            case TUESDAY:
+                numLettersOld = 7;
+                break;
+            case THURSDAY:
+            case SATURDAY:
+                numLettersOld = 8;
+                break;
+            case WEDNESDAY:
+                numLettersOld = 9;
+                break;
+            default:
+                throw new IllegalStateException("Unknown day: " + day);
+        }
+        System.out.println("Old way - " + day + " has " + numLettersOld + " letters");
+        
+        // New way: switch expression directly assigns value
+        int numLetters = switch (day) {
+            case MONDAY, FRIDAY, SUNDAY -> 6;
+            case TUESDAY                -> 7;
+            case THURSDAY, SATURDAY     -> 8;
+            case WEDNESDAY              -> 9;
+        };
+        System.out.println("New way - " + day + " has " + numLetters + " letters");
+    }
+    
+    /// Demonstrates yield statement for complex logic in switch expressions
+    private void demonstrateYieldStatement() {
+        Day day = Day.FRIDAY;
+        
+        String feeling = switch (day) {
+            case MONDAY -> "Terrible";
+            case TUESDAY, WEDNESDAY, THURSDAY -> "Neutral";
+            case FRIDAY -> {
+                String temp = "Great";
+                yield temp + "!!! It's Friday!";
+            }
+            case SATURDAY, SUNDAY -> {
+                // Complex logic requiring a block
+                int mood = calculateWeekendMood();
+                String result = mood > 5 ? "Awesome" : "Good";
+                yield result;
+            }
+        };
+        
+        System.out.println("On " + day + ", feeling: " + feeling);
+    }
+    
+    /// Demonstrates multiple constants per case
+    private void demonstrateMultipleConstants() {
+        String month = "July";
+        
+        int days = switch (month) {
+            case "January", "March", "May", "July", "August", "October", "December" -> 31;
+            case "April", "June", "September", "November" -> 30;
+            case "February" -> 28; // ignoring leap years for simplicity
+            default -> throw new IllegalArgumentException("Invalid month: " + month);
+        };
+        
+        System.out.println(month + " has " + days + " days");
+    }
+    
+    /// Demonstrates exhaustiveness checking with enums
+    private void demonstrateExhaustiveness() {
+        Day day = Day.SATURDAY;
+        
+        // Switch expression on enum must be exhaustive
+        // No default needed if all enum constants are covered
+        boolean isWeekend = switch (day) {
+            case MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY -> false;
+            case SATURDAY, SUNDAY -> true;
+        };
+        
+        System.out.println(day + " is weekend: " + isWeekend);
+        
+        // Alternative with default for future enum additions
+        String dayType = switch (day) {
+            case MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY -> "Weekday";
+            case SATURDAY, SUNDAY -> "Weekend";
+            // default added by compiler for safety
+        };
+        
+        System.out.println(day + " is a " + dayType);
+    }
+    
+    private int calculateWeekendMood() {
+        return 8; // Always high on weekends!
+    }
+    
+    /// Enum for demonstrating switch with enums
+    private enum Day {
+        MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY
+    }
+}

--- a/src/main/resources/JDK12Info.json
+++ b/src/main/resources/JDK12Info.json
@@ -1,5 +1,13 @@
 [
   {
+    "jep": 325,
+    "jdk": 12,
+    "name": "JEP 325 - Switch Expressions (Preview)",
+    "dscr": "First preview of switch expressions. Finalized in JEP 361 (JDK 14).",
+    "link": true,
+    "code": false
+  },
+  {
     "jep": 334,
     "jdk": 12,
     "name": "JEP 334 - JVM Constants API",

--- a/src/main/resources/JDK13Info.json
+++ b/src/main/resources/JDK13Info.json
@@ -1,0 +1,10 @@
+[
+  {
+    "jep": 354,
+    "jdk": 13,
+    "name": "JEP 354 - Switch Expressions (Second Preview)",
+    "dscr": "Second preview of switch expressions introducing yield statement. Finalized in JEP 361 (JDK 14).",
+    "link": true,
+    "code": false
+  }
+]

--- a/src/main/resources/JDK14Info.json
+++ b/src/main/resources/JDK14Info.json
@@ -16,6 +16,14 @@
     "code": false
   },
   {
+    "jep": 361,
+    "jdk": 14,
+    "name": "JEP 361 - Switch Expressions",
+    "dscr": "Extend switch to be used as either a statement or an expression, with arrow labels and yield statement",
+    "link": false,
+    "code": true
+  },
+  {
     "jep": 370,
     "jdk": 14,
     "name": "JEP 370 - Foreign-Memory Access API (Incubator)",


### PR DESCRIPTION
## Description
Implements comprehensive demo for JEP 361 - Switch Expressions (Java 14), along with linking classes for the preview versions in Java 12 (JEP 325) and Java 13 (JEP 354).

Closes #318

## Changes

### Main Demo (Java 14 - JEP 361)
- Created `SwitchExpressionsDemo.java` with comprehensive demonstrations of:
  - **Arrow labels** (`case ... ->`) vs traditional labels
  - **Switch expressions** - using switch as an expression to assign values
  - **Yield statement** - for complex logic blocks within switch expressions
  - **Multiple constants per case** - comma-separated values
  - **Exhaustiveness checking** - especially with enums

### Linking Classes
- **Java 12 - JEP 325:** Created `SwitchExpressionsPreview.java` (first preview with `break` statement)
- **Java 13 - JEP 354:** Created `SwitchExpressionsSecondPreview.java` (second preview introducing `yield`)

### Metadata & Registration
- Updated `JDK14Info.json` with JEP 361 entry
- Created `JDK13Info.json` (first Java 13 metadata file) with JEP 354 entry
- Updated `JDK12Info.json` with JEP 325 entry
- Registered all demos in respective `DemoLoader` classes

## Demo Features Showcased

The JEP 361 demo includes 5 comprehensive demonstrations:

1. **demonstrateArrowLabels()** - Contrast between traditional switch with fall-through and new arrow syntax
2. **demonstrateSwitchExpression()** - Old vs new way of using switch to assign values
3. **demonstrateYieldStatement()** - Using yield for complex logic in switch expressions
4. **demonstrateMultipleConstants()** - Multiple case values with practical example
5. **demonstrateExhaustiveness()** - Exhaustiveness checking with enum examples

## Evolution Across Java Versions

This PR properly documents the evolution of switch expressions:
- **JDK 12 (JEP 325):** First preview - arrow labels, switch expressions with `break <value>`
- **JDK 13 (JEP 354):** Second preview - introduced `yield` statement replacing `break <value>`
- **JDK 14 (JEP 361):** Final version - no changes, became permanent feature

All three classes are properly cross-referenced using `@see` annotations.



## Checklist
- [x] Follows package structure: `org.javademos.java{12,13,14}.jep{325,354,361}`
- [x] Implements `IDemo` interface with proper `info()` and `demo()` methods
- [x] Uses Markdown-style documentation (`///`)
- [x] Added JSON entries to `JDK12Info.json`, `JDK13Info.json`, and `JDK14Info.json`
- [x] Registered in `Java12DemoLoader`, `Java13DemoLoader`, and `Java14DemoLoader` using JEP numbers as keys
- [x] Includes `@author` attribution
- [x] Working code examples covering all major features
- [x] Proper cross-references between related JEPs using `@see` annotations
- [x] Link classes properly reference final implementation