### PR TITLE
Move JEP 358 demo from java17 to java14

### DIFF
--- a/src/main/java/org/javademos/init/Java14DemoLoader.java
+++ b/src/main/java/org/javademos/init/Java14DemoLoader.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.javademos.commons.IDemo;
 import org.javademos.commons.IDemoLoader;
 import org.javademos.java14.jep305.InstanceofPatternMatchingPreview;
+import org.javademos.java14.jep358.NullPointerDemo;
 import org.javademos.java14.jep359.RecordsPreviewDemo;
 import org.javademos.java14.jep361.SwitchExpressionsDemo;
 import org.javademos.java14.jep370.ForeignMemoryAccessDemo;
@@ -16,9 +17,10 @@ public class Java14DemoLoader implements IDemoLoader {
     
     @Override
     public void loadDemos(Map<Integer, IDemo> demos) {
-        demos.put(305, new InstanceofPatternMatchingPreview());
-        demos.put(359, new RecordsPreviewDemo());
-        demos.put(361, new SwitchExpressionsDemo());
-        demos.put(370, new ForeignMemoryAccessDemo());
+        demos.put(305, new InstanceofPatternMatchingPreview()); // JEP 305
+        demos.put(358, new NullPointerDemo()); // JEP 358
+        demos.put(359, new RecordsPreviewDemo()); // JEP 359
+        demos.put(361, new SwitchExpressionsDemo()); // JEP 361
+        demos.put(370, new ForeignMemoryAccessDemo()); // JEP 370
     }
 }

--- a/src/main/java/org/javademos/java14/jep358/NullPointerDemo.java
+++ b/src/main/java/org/javademos/java14/jep358/NullPointerDemo.java
@@ -1,4 +1,4 @@
-package org.javademos.java17.nullpointer;
+package org.javademos.java14.jep358;
 
 import org.javademos.commons.IDemo;
 
@@ -10,13 +10,13 @@ import org.javademos.commons.IDemo;
 /// Further reading:
 /// - [Java 14 NullPointerException](https://www.baeldung.com/java-14-nullpointerexception)
 /// 
-/// @author alois.seckar@gmail.com
+/// @author Abhineshhh
 @SuppressWarnings("null") // we are deliberately invoking `NullPointerException` in this demo
 public class NullPointerDemo implements IDemo {
 
     @Override
     public void demo() {
-        info("NULL POINTER DEMO", "Examples of 'helpful NullPointer' errors\nintroduced in Java 14");
+        info(358);
         
         try {
             // this will raise NullPointerException, but with helpful hint

--- a/src/main/java/org/javademos/java14/jep358/NullPointerLevel1.java
+++ b/src/main/java/org/javademos/java14/jep358/NullPointerLevel1.java
@@ -1,4 +1,4 @@
-package org.javademos.java17.nullpointer;
+package org.javademos.java14.jep358;
 
 import lombok.Getter;
 
@@ -7,7 +7,7 @@ import lombok.Getter;
  * Here we have 4-level nested class structure and somewhere on the way
  * one element is 'null', so invoking method on it will raise 'NullPointer'.
  * 
- * @author alois.seckar@gmail.com
+ * @author Abhineshhh
  */
 public class NullPointerLevel1 {
     

--- a/src/main/java/org/javademos/java14/jep358/NullPointerLevel2.java
+++ b/src/main/java/org/javademos/java14/jep358/NullPointerLevel2.java
@@ -1,4 +1,4 @@
-package org.javademos.java17.nullpointer;
+package org.javademos.java14.jep358;
 
 import lombok.Getter;
 
@@ -7,7 +7,7 @@ import lombok.Getter;
  * Here we have 4-level nested class structure and somewhere on the way
  * one element is 'null', so invoking method on it will raise 'NullPointer'.
  * 
- * @author alois.seckar@gmail.com
+ * @author Abhineshhh
  */
 public class NullPointerLevel2 {
     

--- a/src/main/java/org/javademos/java14/jep358/NullPointerLevel3.java
+++ b/src/main/java/org/javademos/java14/jep358/NullPointerLevel3.java
@@ -1,4 +1,4 @@
-package org.javademos.java17.nullpointer;
+package org.javademos.java14.jep358;
 
 import lombok.Getter;
 
@@ -7,7 +7,7 @@ import lombok.Getter;
  * Here we have 4-level nested class structure and somewhere on the way
  * one element is 'null', so invoking method on it will raise 'NullPointer'.
  * 
- * @author alois.seckar@gmail.com
+ * @author Abhineshhh
  */
 public class NullPointerLevel3 {
     

--- a/src/main/java/org/javademos/java14/jep358/NullPointerLevel4.java
+++ b/src/main/java/org/javademos/java14/jep358/NullPointerLevel4.java
@@ -1,11 +1,11 @@
-package org.javademos.java17.nullpointer;
+package org.javademos.java14.jep358;
 
 /**
  * Simple class to show 'helpful' NullPointerExceptions from Java 14.
  * Here we have 4-level nested class structure and somewhere on the way
  * one element is 'null', so invoking method on it will raise 'NullPointer'.
  * 
- * @author alois.seckar@gmail.com
+ * @author Abhineshhh
  */
 public class NullPointerLevel4 {
     

--- a/src/main/resources/JDK14Info.json
+++ b/src/main/resources/JDK14Info.json
@@ -8,6 +8,14 @@
     "code": false
   },
   {
+    "jep": 358,
+    "jdk": 14,
+    "name": "JEP 358 - Helpful NullPointerExceptions",
+    "dscr": "Enhances NullPointerExceptions to describe precisely which variable was null",
+    "link": false,
+    "code": true
+  },
+  {
     "jep": 359,
     "jdk": 14,
     "name": "JEP 359 - Records (Preview)",


### PR DESCRIPTION

Fixes #329

This PR relocates the JEP 358 (Helpful NullPointerExceptions) demo from its legacy location in `java17/nullpointer` to its proper home in `java14/jep358`, as this feature was introduced in Java 14.

## Changes

- Moved `NullPointerDemo.java` and supporting classes (`NullPointerLevel1-4.java`) from `java17/nullpointer/` to `java14/jep358/`
- Updated package declarations to `org.javademos.java14.jep358`
- Updated `info()` method call to use JEP number parameter (`info(358)`)
- Added JEP 358 entry to `JDK14Info.json` with proper metadata
- Registered demo in `Java14DemoLoader.java` (ordered by JEP number)
- Removed old files from `java17/nullpointer/` directory


